### PR TITLE
auth system compatibility

### DIFF
--- a/src/app/login/login-page.test.tsx
+++ b/src/app/login/login-page.test.tsx
@@ -5,9 +5,10 @@ import { describe, expect, it } from "vitest";
 import { API_ERROR_MESSAGES, API_URL } from "@/config/constants";
 import { getErrorMessage } from "@/lib/error-handling";
 import { getToaster, renderWithProviders } from "@/tests/helpers/react";
-import { MOCK_PASSWORD, MOCK_TOKEN, MOCK_USER } from "@/tests/mocks/constants";
+import { MOCK_PASSWORD, MOCK_USER } from "@/tests/mocks/constants";
 import { MOCK_USE_ROUTER } from "@/tests/mocks/functions";
 import { server } from "@/tests/mocks/server";
+import type { User } from "@/types/api";
 
 import LoginPage from "./page";
 
@@ -80,16 +81,17 @@ describe("Login page", () => {
   it("should accept valid credentials", enterValidCredentials);
 
   it("should fall back to email if user has no full name", async () => {
-    const { fullName, ...user } = MOCK_USER.valid;
     server.use(
-      http.post(`${API_URL}/auth/login`, () =>
-        HttpResponse.json({ user, token: MOCK_TOKEN.valid }),
+      http.get(`${API_URL}/auth/me`, () =>
+        HttpResponse.json({
+          user: { ...MOCK_USER.valid, fullName: null } satisfies User,
+        }),
       ),
     );
 
     await enterValidCredentials();
     expect(getToaster()).toHaveTextContent(
-      `Pomyślnie zalogowano jako ${user.email}`,
+      `Pomyślnie zalogowano jako ${MOCK_USER.valid.email}`,
     );
   });
 });

--- a/src/hooks/use-auth.tsx
+++ b/src/hooks/use-auth.tsx
@@ -6,12 +6,12 @@ import { toast } from "sonner";
 import { AUTH_STATE_COOKIE_NAME } from "@/config/constants";
 import { getCookieOptions, parseAuthCookie } from "@/lib/cookies";
 import { fetchMutation } from "@/lib/fetch-utils";
-import { getUserDisplayName } from "@/lib/helpers";
+import { getCurrentUser, getUserDisplayName } from "@/lib/helpers";
 import { authStateAtom } from "@/stores/auth";
 import type {
   AuthState,
+  LogInResponse,
   MessageResponse,
-  SuccessResponse,
   User,
 } from "@/types/api";
 import type { LoginFormValues } from "@/types/forms";
@@ -45,7 +45,7 @@ const parseAuthState = (
     : {
         isAuthenticated: true,
         user: state.user,
-        accessToken: state.token,
+        accessToken: state.accessToken,
       };
 
 /** React hook for client-side authentication-related operations. */
@@ -74,26 +74,45 @@ export function useAuth(): AuthContext {
         `Cannot log in: already authenticated as ${getUserDisplayName(authState.user)}`,
       );
     }
-    const response = await fetchMutation<AuthState>("/auth/login", {
-      body: data,
-    });
-    Cookies.set(AUTH_STATE_COOKIE_NAME, ...getCookieOptions(response));
-    setAuthState(response);
-    return response;
+    const { accessToken, refreshToken } = await fetchMutation<LogInResponse>(
+      "/auth/login",
+      {
+        body: data,
+      },
+    );
+    const newState: AuthState = {
+      accessToken,
+      refreshToken,
+      user: await getCurrentUser(accessToken),
+    };
+    Cookies.set(AUTH_STATE_COOKIE_NAME, ...getCookieOptions(newState));
+    setAuthState(newState);
+    return newState;
   }
 
-  async function logout() {
+  /** Logs out by deleting the refresh token. Can only be called when logged in.
+   *
+   *  @param all if set to true, will invalidate all refresh tokens, causing logout on all devices.
+   */
+  async function logout(all = false) {
     if (authState == null) {
       throw new Error("Cannot log out when not authenticated");
     }
-    const result = await fetchMutation<SuccessResponse<MessageResponse>>(
-      "/auth/logout",
-      {},
+    const result = await fetchMutation<MessageResponse>(
+      `/auth/logout?all=${all ? "true" : "false"}`,
+      {
+        body: { refreshToken: authState.refreshToken },
+      },
     );
-    if (!result.success) {
-      throw new Error(result.message || "Logout failed");
+    const expectedMessage = all
+      ? "All refresh tokens marked as invalid"
+      : "Invalidated the provided refresh token";
+    if (result.message !== expectedMessage) {
+      throw new Error(`Logout failed: ${result.message || "<no message>"}`);
     }
-    toast.success("Wylogowano pomyślnie.");
+    toast.success(
+      `Wylogowano pomyślnie${all ? " ze wszystkich urządzeń" : ""}.`,
+    );
     Cookies.remove(AUTH_STATE_COOKIE_NAME);
     setAuthState(null);
   }

--- a/src/lib/fetch-utils.ts
+++ b/src/lib/fetch-utils.ts
@@ -71,7 +71,7 @@ async function handleResponse<T>(response: Response): Promise<NonNullable<T>> {
   return responseBody;
 }
 
-const getAccessToken = () => getAuthState()?.token;
+const getAccessToken = () => getAuthState()?.accessToken;
 
 function createRequest(
   endpoint: string,

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -4,6 +4,8 @@ import { FORM_ERROR_MESSAGES } from "@/config/constants";
 import type { User } from "@/types/api";
 import type { SelectInputOption } from "@/types/forms";
 
+import { fetchQuery } from "./fetch-utils";
+
 /** Prefers the user's full name, falling back to their email. */
 export const getUserDisplayName = (user: User): string =>
   user.fullName ?? user.email;
@@ -66,3 +68,10 @@ export const encodeQueryParameters = (
   );
   return pairArray.join("&");
 };
+
+export async function getCurrentUser(accessTokenOverride?: string) {
+  const { user } = await fetchQuery<{ user: User }>("auth/me", {
+    accessTokenOverride,
+  });
+  return user;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,8 +4,9 @@ import { NextResponse } from "next/server";
 import { AUTH_STATE_COOKIE_NAME } from "@/config/constants";
 import { Resource } from "@/config/enums";
 import { getCookieOptions, parseAuthCookie } from "@/lib/cookies";
-import { fetchQuery } from "@/lib/fetch-utils";
 import type { User } from "@/types/api";
+
+import { getCurrentUser } from "./lib/helpers";
 
 const REQUIRED_ROUTE_PERMISSIONS: Record<string, string[] | undefined> = {
   "/login": [],
@@ -30,9 +31,7 @@ async function verifyUserCookie(
   }
   let user: User;
   try {
-    user = await fetchQuery<User>("/auth/me", {
-      accessTokenOverride: authState.token,
-    });
+    user = await getCurrentUser(authState.accessToken);
   } catch (error) {
     console.warn("Invalid token in cookie:", error);
     response.cookies.delete(AUTH_STATE_COOKIE_NAME);

--- a/src/tests/helpers/auth.ts
+++ b/src/tests/helpers/auth.ts
@@ -1,5 +1,9 @@
 import { fetchMutation } from "@/lib/fetch-utils";
-import type { AuthState, MessageResponse, SuccessResponse } from "@/types/api";
+import type {
+  LogInResponse,
+  MessageResponse,
+  SuccessResponse,
+} from "@/types/api";
 import type { LoginFormValues } from "@/types/forms";
 
 import { TEST_USER_EMAIL, TEST_USER_PASSWORD } from "../mocks/constants";
@@ -15,14 +19,14 @@ export async function generateAccessToken(): Promise<string> {
     password: TEST_USER_PASSWORD,
     rememberMe: false,
   };
-  const response = await fetchMutation<AuthState>("/auth/login", {
+  const response = await fetchMutation<LogInResponse>("auth/login", {
     body,
   });
-  return response.token;
+  return response.accessToken;
 }
 
 export async function deleteAccessToken(accessToken: string) {
-  await fetchMutation<SuccessResponse<MessageResponse>>("/auth/logout", {
+  await fetchMutation<SuccessResponse<MessageResponse>>("auth/logout", {
     accessTokenOverride: accessToken,
   });
 }

--- a/src/tests/mocks/constants.ts
+++ b/src/tests/mocks/constants.ts
@@ -26,8 +26,9 @@ export const MOCK_PASSWORD = {
 } satisfies Mocked<string>;
 
 export const MOCK_TOKEN = {
-  valid: "exp.validJwtToken.1234567890",
-} satisfies Mocked<string>;
+  access: { valid: "exp.validJwtToken.1234567890" },
+  refresh: { valid: "exp.validRefreshToken.0000000000" },
+} satisfies { access: Mocked<string>; refresh: Mocked<string> };
 
 export const MOCK_RESPONSE = {
   validationFailure: () =>

--- a/src/tests/mocks/handlers.ts
+++ b/src/tests/mocks/handlers.ts
@@ -2,6 +2,7 @@ import type { RequestHandler } from "msw";
 import { HttpResponse, http } from "msw";
 
 import { API_URL } from "@/config/constants";
+import type { ErrorResponse, LogInResponse } from "@/types/api";
 
 import {
   MOCK_PASSWORD,
@@ -11,14 +12,20 @@ import {
 } from "./constants";
 
 export const handlers = [
+  http.get(`${API_URL}/auth/me`, () =>
+    HttpResponse.json({ user: MOCK_USER.valid }),
+  ),
   http.post(`${API_URL}/auth/login`, async ({ request }) => {
     const body = (await request.json()) as { email: string; password?: string };
     return body.email === MOCK_USER.valid.email &&
       body.password === MOCK_PASSWORD.valid
       ? HttpResponse.json({
-          user: MOCK_USER.valid,
-          token: MOCK_TOKEN.valid,
-        })
+          type: "bearer",
+          accessToken: MOCK_TOKEN.access.valid,
+          refreshToken: MOCK_TOKEN.refresh.valid,
+          accessExpiresInMs: 3_600_000,
+          refreshExpiresInMs: 604_800_000,
+        } satisfies LogInResponse)
       : body.password == null || body.password === ""
         ? MOCK_RESPONSE.validationFailure()
         : HttpResponse.json(
@@ -27,7 +34,7 @@ export const handlers = [
                 message: "Invalid user credentials",
                 code: "E_INVALID_CREDENTIALS",
               },
-            },
+            } satisfies ErrorResponse,
             { status: 400 },
           );
   }),

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -57,9 +57,19 @@ export interface User extends DatedResource {
 }
 
 /** As returned from POST /auth/login */
+export interface LogInResponse {
+  type: "bearer";
+  accessToken: string;
+  refreshToken: string;
+  accessExpiresInMs: number;
+  refreshExpiresInMs: number;
+}
+
+/** As returned from POST /auth/login */
 export interface AuthState {
+  accessToken: string;
+  refreshToken: string;
   user: User;
-  token: string;
 }
 
 /** As returned from GET /files/{id} */


### PR DESCRIPTION
zmiana systemu autoryzacyjnego umożliwiająca logowanie po najnowszych zmianach w API

jedynie dodaje funkcję wylogowywania na wszystkich urządzeniach, ale na razie jest to bezużyteczne bo refresh tokeny nie są nigdzie użyte (użytkownik po godzinie musi się sam wylogować i zalogować ponownie aby działało)

role i odświeżanie w nowej prce bo chce to już mieć na prodzie