### PR TITLE
fix(tests): use hardcoded test day

### DIFF
--- a/src/components/inputs/date-picker.test.tsx
+++ b/src/components/inputs/date-picker.test.tsx
@@ -26,6 +26,7 @@ function renderDatePicker(initialValue?: Date) {
 }
 
 const now = new Date();
+now.setDate(15); // use the middle of the month as the edge days are repeated in previous/next month views
 now.setHours(0, 0, 0, 0);
 const today = now.getDate().toString();
 


### PR DESCRIPTION
test nie przechodził w niektóre dni, a konkretniej w te, które są widoczne dwukrotnie w date pickerze:
<img width="900" height="196" alt="image" src="https://github.com/user-attachments/assets/740e10ac-652c-4527-8f59-227a4f47c6c5" />

np dla października byłyby to 28, 29, 30 i 1:
<img width="335" height="387" alt="image" src="https://github.com/user-attachments/assets/2a79ee2c-e586-4b0c-9433-528010224760" />

zmieniono na środek miesiąca żeby mieć pewność, że się ten dzień nie powtórzy