### PR TITLE
feat(arf): add resizable image inputs

### DIFF
--- a/src/components/inputs/image-upload.tsx
+++ b/src/components/inputs/image-upload.tsx
@@ -12,6 +12,7 @@ import { Button } from "@/components/ui/button";
 import { FormControl, FormLabel } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { ImageType } from "@/config/enums";
+import type { ImageSize } from "@/features/abstract-resource-form";
 import { ApiImage, uploadFile, useMutationWrapper } from "@/features/backend";
 import { declineNoun } from "@/features/polish";
 import type { Resource } from "@/features/resources";
@@ -20,15 +21,40 @@ import type {
   ResourceSchemaKey,
 } from "@/features/resources/types";
 import { getToastMessages } from "@/lib/get-toast-messages";
+import { cn } from "@/lib/utils";
 import type { WrapperProps } from "@/types/components";
 
 import { ImagePreviewModal } from "../presentation/image-preview-modal";
 
-function InputBox({ children }: WrapperProps) {
+function getImageSizeClasses(size: ImageSize): string {
+  switch (size) {
+    case "small": {
+      return "md:size-32";
+    }
+    case "medium": {
+      return "md:size-48";
+    }
+    case "large": {
+      return "md:size-64";
+    }
+    case "wide": {
+      return "md:h-48 md:w-full aspect-video";
+    }
+  }
+}
+
+function InputBox({
+  children,
+  size = "medium",
+}: WrapperProps & { size?: ImageSize }) {
   return (
     <InputSlot
       renderAs="div"
-      className="aspect-video h-fit max-h-48 w-full overflow-hidden rounded-lg md:size-48"
+      className={cn(
+        "h-fit w-full overflow-hidden rounded-lg",
+        size !== "wide" && "aspect-video max-h-48",
+        getImageSizeClasses(size),
+      )}
     >
       {children}
     </InputSlot>
@@ -41,6 +67,7 @@ export function ImageUpload<T extends Resource>({
   value,
   label,
   type = ImageType.Logo,
+  size = "medium",
   existingImage,
   resourceData,
   disabled,
@@ -50,6 +77,7 @@ export function ImageUpload<T extends Resource>({
   onChange: (value: string | null) => void;
   label: string;
   type?: ImageType;
+  size?: ImageSize;
   existingImage?: ReactNode;
   resourceData?: ResourceFormValues<T>;
   disabled?: boolean;
@@ -112,7 +140,7 @@ export function ImageUpload<T extends Resource>({
       <FormLabel className="flex flex-col items-start space-y-1.5">
         {label}
         {hasImage ? null : (
-          <InputBox>
+          <InputBox size={size}>
             <div className="flex size-full cursor-pointer flex-col items-center justify-center">
               <Camera className="text-image-input-icon size-12" />
               <span className="text-muted-foreground text-xs">
@@ -123,7 +151,7 @@ export function ImageUpload<T extends Resource>({
         )}
       </FormLabel>
       {hasImage ? (
-        <InputBox>
+        <InputBox size={size}>
           <FormControl>
             <Button
               type="button"

--- a/src/features/abstract-resource-form/index.ts
+++ b/src/features/abstract-resource-form/index.ts
@@ -5,3 +5,5 @@ export * from "./components/abstract-resource-form";
 export * from "./hooks/use-arf-sheet";
 
 export * from "./providers/arf-sheet-provider";
+
+export type { ImageSize } from "./types/inputs";

--- a/src/features/abstract-resource-form/types/inputs.ts
+++ b/src/features/abstract-resource-form/types/inputs.ts
@@ -9,6 +9,8 @@ import type {
   ResourceSchemaKey,
 } from "@/features/resources/types";
 
+export type ImageSize = "small" | "medium" | "large" | "wide";
+
 export interface FormInputBase {
   label: string;
   /** For fields which should only be set on creation, and not in the edit form. */
@@ -51,7 +53,11 @@ type ArrayInputs<T extends Resource> = Partial<
 
 export interface AbstractResourceFormInputs<T extends Resource> {
   /** Image upload inputs for image key fields. */
-  imageInputs?: FormInput<T, z.ZodString, { type: ImageType }>;
+  imageInputs?: FormInput<
+    T,
+    z.ZodString,
+    { type: ImageType; size?: ImageSize }
+  >;
   /** Standard text input fields. */
   textInputs?: FormInput<T>;
   /** Number input fields for numeric values. */

--- a/src/features/resources/data/resource-metadata.ts
+++ b/src/features/resources/data/resource-metadata.ts
@@ -156,7 +156,11 @@ export const RESOURCE_METADATA = {
           description: { label: "Opis" },
         },
         imageInputs: {
-          coverPhotoKey: { label: "Zdjęcie w tle", type: ImageType.Banner },
+          coverPhotoKey: {
+            label: "Zdjęcie w tle",
+            type: ImageType.Banner,
+            size: "wide",
+          },
         },
       },
       defaultValues: {
@@ -546,7 +550,7 @@ export const RESOURCE_METADATA = {
     form: {
       inputs: {
         imageInputs: {
-          imageKey: { label: "Zdjęcie", type: ImageType.Banner },
+          imageKey: { label: "Zdjęcie", type: ImageType.Banner, size: "wide" },
         },
         textInputs: {
           title: { label: "Tytuł" },
@@ -851,8 +855,8 @@ export const RESOURCE_METADATA = {
     form: {
       inputs: {
         imageInputs: {
-          logoKey: { label: "Logo", type: ImageType.Logo },
-          coverKey: { label: "Baner", type: ImageType.Banner },
+          logoKey: { label: "Logo", type: ImageType.Logo, size: "small" },
+          coverKey: { label: "Baner", type: ImageType.Banner, size: "wide" },
         },
         textInputs: {
           name: { label: "Nazwa" },


### PR DESCRIPTION
Resolves #89 

This pull request adds support for specifying image size variants in the image upload input component and updates resource metadata to use these new size options. The changes improve flexibility and consistency in how images are displayed throughout the application.

**Image upload component enhancements:**

- Added a new `ImageSize` type with options `"small"`, `"medium"`, `"large"`, and `"wide"`, and updated the `ImageUpload` component to accept a `size` prop for controlling image display size. [[1]](diffhunk://#diff-a7d484ab84bac267d86a0d48e2f5cf3f8c1d416087d5e96dd5d9e972ceb10b68R12-R13) [[2]](diffhunk://#diff-5ea25955f1cd320f2f45842d0e9964945e740889e8d5c00c291e6d6c76d5ed8dR15) [[3]](diffhunk://#diff-5ea25955f1cd320f2f45842d0e9964945e740889e8d5c00c291e6d6c76d5ed8dR70) [[4]](diffhunk://#diff-5ea25955f1cd320f2f45842d0e9964945e740889e8d5c00c291e6d6c76d5ed8dR80) [[5]](diffhunk://#diff-5ea25955f1cd320f2f45842d0e9964945e740889e8d5c00c291e6d6c76d5ed8dR24-R57)
- Refactored the `InputBox` component to apply different CSS classes based on the selected image size, ensuring images are rendered appropriately for their context.
- Updated usages of `InputBox` within `ImageUpload` to pass the new `size` prop. [[1]](diffhunk://#diff-5ea25955f1cd320f2f45842d0e9964945e740889e8d5c00c291e6d6c76d5ed8dL115-R143) [[2]](diffhunk://#diff-5ea25955f1cd320f2f45842d0e9964945e740889e8d5c00c291e6d6c76d5ed8dL126-R154)

**Resource form and metadata updates:**

- Extended resource form input types to allow specifying the `size` property for image inputs.
- Updated resource metadata in `RESOURCE_METADATA` to specify appropriate image sizes for various image fields, such as using `"wide"` for banners and `"small"` for logos. [[1]](diffhunk://#diff-959d01adc71db67a387af8e05c65b3d035655df4e4b4a2b0eb79647771ec125cL107-R111) [[2]](diffhunk://#diff-959d01adc71db67a387af8e05c65b3d035655df4e4b4a2b0eb79647771ec125cL484-R488) [[3]](diffhunk://#diff-959d01adc71db67a387af8e05c65b3d035655df4e4b4a2b0eb79647771ec125cL774-R779)

**Type and export adjustments:**

- Exported the new `ImageSize` type from the abstract resource form module for use in other parts of the codebase.