### PR TITLE
ci(coverage): add permission scope

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,5 +1,8 @@
 name: Check Coverage Regression
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Solvro/web-topwr/security/code-scanning/5](https://github.com/Solvro/web-topwr/security/code-scanning/5)

To fix the problem, explicitly declare least-privilege `GITHUB_TOKEN` permissions in the workflow. This workflow only needs to read repository contents to check out code and run tests; it does not need to write to the repository, manage issues, or modify PRs. Therefore, the safest change is to add `permissions: contents: read` at the workflow (top) level so it applies to all jobs, or specifically under the `coverage` job. Adding it at the top keeps the file simple and documents the workflow’s needs without changing existing functionality.

Concretely, in `.github/workflows/coverage.yml`, add a `permissions` block near the top-level keys, e.g. after `name:` and before `on:`. This will ensure the `GITHUB_TOKEN` used by `actions/checkout` and any Git operations has read-only access to repository contents. No additional imports, methods, or definitions are required because this is a configuration-only change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
