### PR TITLE
fix: ordering hallucinations and per milestone contributors ordering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@radix-ui/react-tooltip": "^1.2.8",
         "@solvro/next-view-transitions": "^0.4.3",
         "@t3-oss/env-nextjs": "^0.13.11",
-        "@tanstack/react-query": "^5.90.5",
+        "@tanstack/react-query": "^5.101.0",
         "@tiptap/extension-code-block-lowlight": "~3.8.0",
         "@tiptap/extension-color": "~3.8.0",
         "@tiptap/extension-horizontal-rule": "~3.8.0",
@@ -6313,9 +6313,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.90.20",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.20.tgz",
-      "integrity": "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==",
+      "version": "5.101.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.0.tgz",
+      "integrity": "sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -6323,12 +6323,12 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.90.21",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.21.tgz",
-      "integrity": "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg==",
+      "version": "5.101.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.0.tgz",
+      "integrity": "sha512-rLlJXSpkqfizLWgkR5+eLeIk0MvTx/meEIR7LRjxic+qxiQP8zVjq7BqQkiCMNLQBlLfuOLqqr6KO5GtrDlmSg==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.90.20"
+        "@tanstack/query-core": "5.101.0"
       },
       "funding": {
         "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@radix-ui/react-tooltip": "^1.2.8",
         "@solvro/next-view-transitions": "^0.4.3",
         "@t3-oss/env-nextjs": "^0.13.11",
-        "@tanstack/react-query": "^5.101.0",
+        "@tanstack/react-query": "^5.101.2",
         "@tiptap/extension-code-block-lowlight": "~3.8.0",
         "@tiptap/extension-color": "~3.8.0",
         "@tiptap/extension-horizontal-rule": "~3.8.0",
@@ -6313,9 +6313,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.101.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.0.tgz",
-      "integrity": "sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow==",
+      "version": "5.101.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.2.tgz",
+      "integrity": "sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -6323,12 +6323,12 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.101.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.0.tgz",
-      "integrity": "sha512-rLlJXSpkqfizLWgkR5+eLeIk0MvTx/meEIR7LRjxic+qxiQP8zVjq7BqQkiCMNLQBlLfuOLqqr6KO5GtrDlmSg==",
+      "version": "5.101.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.2.tgz",
+      "integrity": "sha512-seDkr6kzGzX1okaaTtZPtgA688CDPlXUz1C6xSg0ESqn04Vuc8tlrYms1s3de+znBqhPVxFRfpAfUf+6XvfPWg==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.101.0"
+        "@tanstack/query-core": "5.101.2"
       },
       "funding": {
         "type": "github",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "@solvro/next-view-transitions": "^0.4.3",
     "@t3-oss/env-nextjs": "^0.13.11",
-    "@tanstack/react-query": "^5.101.0",
+    "@tanstack/react-query": "^5.101.2",
     "@tiptap/extension-code-block-lowlight": "~3.8.0",
     "@tiptap/extension-color": "~3.8.0",
     "@tiptap/extension-horizontal-rule": "~3.8.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "@solvro/next-view-transitions": "^0.4.3",
     "@t3-oss/env-nextjs": "^0.13.11",
-    "@tanstack/react-query": "^5.90.5",
+    "@tanstack/react-query": "^5.101.0",
     "@tiptap/extension-code-block-lowlight": "~3.8.0",
     "@tiptap/extension-color": "~3.8.0",
     "@tiptap/extension-horizontal-rule": "~3.8.0",

--- a/src/components/presentation/logout-button.tsx
+++ b/src/components/presentation/logout-button.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useQueryClient } from "@tanstack/react-query";
 import { LogOut } from "lucide-react";
 import { toast } from "sonner";
 
@@ -12,6 +13,7 @@ import { getToastMessages } from "@/lib/get-toast-messages";
 
 export function LogoutButton() {
   const { logout, clearAuthState } = useAuthentication();
+  const queryClient = useQueryClient();
   const router = useRouter();
 
   const { mutateAsync, isPending } = useMutationWrapper<
@@ -28,6 +30,7 @@ export function LogoutButton() {
         router.push("/login", {
           onSnapshotTaken: () => {
             clearAuthState();
+            queryClient.clear();
           },
         });
       },

--- a/src/components/providers/root-providers.tsx
+++ b/src/components/providers/root-providers.tsx
@@ -1,22 +1,38 @@
 "use client";
-
 import { ViewTransitions } from "@solvro/next-view-transitions";
-import { QueryClient } from "@tanstack/react-query";
+import { QueryClient, environmentManager } from "@tanstack/react-query";
 
 import { globalStore } from "@/stores/global";
 import type { WrapperProps } from "@/types/components";
 
 import { InternalProviders } from "./internal-providers";
 
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      gcTime: 1000 * 60 * 60 * 24,
+// https://tanstack.com/query/latest/docs/framework/react/guides/advanced-ssr
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 60 * 1000,
+        gcTime: 1000 * 60 * 60 * 24,
+      },
     },
-  },
-});
+  });
+}
+
+let browserQueryClient: QueryClient | undefined;
+
+function getQueryClient() {
+  if (environmentManager.isServer()) {
+    return makeQueryClient();
+  } else {
+    browserQueryClient ??= makeQueryClient();
+    return browserQueryClient;
+  }
+}
 
 export function RootProviders({ children }: WrapperProps) {
+  const queryClient = getQueryClient();
+
   return (
     <ViewTransitions>
       <InternalProviders queryClient={queryClient} jotaiStore={globalStore}>

--- a/src/features/abstract-resource-form/components/arf-relation-input.tsx
+++ b/src/features/abstract-resource-form/components/arf-relation-input.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { get } from "react-hook-form";
 import type { Control } from "react-hook-form";
 import { toast } from "sonner";
@@ -36,11 +37,13 @@ import { sanitizeId, toTitleCase } from "@/utils";
 import { useArfRelation } from "../hooks/use-arf-relation";
 import { useArfRelationMutation } from "../hooks/use-arf-relation-mutation";
 import { useArfSheet } from "../hooks/use-arf-sheet";
+import { getItemPivotOrder } from "../utils/get-item-pivot-order";
 import { getMutationConfig } from "../utils/get-mutation-config";
 import { isExistingItem } from "../utils/is-existing-item";
 import { ArfInput } from "./arf-input";
 import { ArfPivotData } from "./arf-pivot-data";
 import { OrderableMultiSelect } from "./orderable-multi-select";
+import { OrderablePivotMultiSelect } from "./orderable-pivot-multi-select";
 
 export function ArfRelationInput<
   T extends Resource,
@@ -145,11 +148,23 @@ export function ArfRelationInput<
   const isRelationOrderable =
     isOrderableResource(resourceRelation) &&
     relationDefinition.type !== RelationType.ManyToMany;
+  const isPivotOrderable =
+    relationDefinition.type === RelationType.ManyToMany &&
+    relationDefinition.orderable === true;
   const sortedQueriedRelations = isRelationOrderable
     ? [...queriedRelations].toSorted((a, b) =>
         "order" in a && "order" in b ? a.order - b.order : 1,
       )
-    : queriedRelations;
+    : isPivotOrderable
+      ? [...queriedRelations].toSorted((a, b) => {
+          const orderA = getItemPivotOrder(a);
+          const orderB = getItemPivotOrder(b);
+          if (orderA !== undefined && orderB !== undefined) {
+            return orderA - orderB;
+          }
+          return 1;
+        })
+      : queriedRelations;
   const selectedValues = sortedQueriedRelations.flatMap((item) => {
     const value = get(item, primaryKeyField, null) as ResourcePk | null;
     return value == null ? [] : String(value);
@@ -264,16 +279,29 @@ export function ArfRelationInput<
     defaultValue: [...new Set(selectedValues)],
   } satisfies React.ComponentProps<typeof MultiSelect>;
 
-  const multiselect = isRelationOrderable ? (
-    <OrderableMultiSelect
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- type guard doesn't narrow generics
-      resourceRelation={resourceRelation as OrderableResource}
-      items={sortedQueriedRelations as ResourceDataType<OrderableResource>[]}
-      multiSelectProps={multiSelectProps}
-    />
-  ) : (
-    <MultiSelect {...multiSelectProps} />
-  );
+  let multiselect: ReactNode;
+  if (isRelationOrderable) {
+    multiselect = (
+      <OrderableMultiSelect
+        resourceRelation={resourceRelation as OrderableResource}
+        items={sortedQueriedRelations as ResourceDataType<OrderableResource>[]}
+        multiSelectProps={multiSelectProps}
+      />
+    );
+  } else if (isPivotOrderable && relationDefinition.pivotData != null) {
+    multiselect = (
+      <OrderablePivotMultiSelect
+        resource={resource}
+        resourceRelation={resourceRelation}
+        endpoint={endpoint}
+        pivotData={relationDefinition.pivotData}
+        items={sortedQueriedRelations}
+        multiSelectProps={multiSelectProps}
+      />
+    );
+  } else {
+    multiselect = <MultiSelect {...multiSelectProps} />;
+  }
   return relationDefinition.type === RelationType.ManyToMany ? (
     // TODO: allow m:n relation inputs to be immutable
     <Label className="flex-col items-start">

--- a/src/features/abstract-resource-form/components/arf-relation-input.tsx
+++ b/src/features/abstract-resource-form/components/arf-relation-input.tsx
@@ -142,7 +142,9 @@ export function ArfRelationInput<
     );
   }
   const queriedRelations = unsafeQueriedRelations ?? [];
-  const isRelationOrderable = isOrderableResource(resourceRelation);
+  const isRelationOrderable =
+    isOrderableResource(resourceRelation) &&
+    relationDefinition.type !== RelationType.ManyToMany;
   const sortedQueriedRelations = isRelationOrderable
     ? [...queriedRelations].toSorted((a, b) =>
         "order" in a && "order" in b ? a.order - b.order : 1,

--- a/src/features/abstract-resource-form/components/orderable-multi-select.tsx
+++ b/src/features/abstract-resource-form/components/orderable-multi-select.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useRef } from "react";
+import { arrayMove } from "@dnd-kit/sortable";
+import { useEffect, useRef } from "react";
 
 import { MultiSelect } from "@/components/ui/multi-select";
 import { calculateNewSortValue } from "@/features/abstract-resource-list";
@@ -23,7 +24,10 @@ export function OrderableMultiSelect<T extends OrderableResource>({
   multiSelectProps,
 }: OrderableMultiSelectProps<T>) {
   const itemsRef = useRef(items);
-  itemsRef.current = items;
+
+  useEffect(() => {
+    itemsRef.current = items;
+  }, [items]);
 
   const { mutateOrder } = useRelationOrderMutation({ resourceRelation });
 
@@ -33,6 +37,9 @@ export function OrderableMultiSelect<T extends OrderableResource>({
       oldIndex,
       newIndex,
     );
+
+    itemsRef.current = arrayMove(itemsRef.current, oldIndex, newIndex);
+
     void mutateOrder(id, order);
   };
 

--- a/src/features/abstract-resource-form/components/orderable-pivot-multi-select.tsx
+++ b/src/features/abstract-resource-form/components/orderable-pivot-multi-select.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { arrayMove } from "@dnd-kit/sortable";
+import { useEffect, useRef } from "react";
+import type { ComponentProps } from "react";
+
+import { MultiSelect } from "@/components/ui/multi-select";
+import { calculateNewSortValue } from "@/features/abstract-resource-list";
+import type { Resource } from "@/features/resources";
+import type {
+  OrderableResource,
+  PivotDataDefinition,
+  ResourceDataType,
+  ResourcePk,
+  ResourceRelation,
+} from "@/features/resources/types";
+
+import { usePivotRelationOrderMutation } from "../hooks/use-pivot-relation-order-mutation";
+import { getItemPivotOrder, hasMeta } from "../utils/get-item-pivot-order";
+
+export function OrderablePivotMultiSelect<
+  T extends Resource,
+  L extends ResourceRelation<T>,
+>({
+  resource,
+  resourceRelation,
+  endpoint,
+  pivotData,
+  items,
+  multiSelectProps,
+}: {
+  resource: T;
+  resourceRelation: L;
+  endpoint: string;
+  pivotData: PivotDataDefinition;
+  items: ResourceDataType<L>[];
+  multiSelectProps: ComponentProps<typeof MultiSelect>;
+}) {
+  const itemsRef = useRef(items);
+
+  useEffect(() => {
+    itemsRef.current = items;
+  }, [items]);
+
+  const { mutateOrder } = usePivotRelationOrderMutation({
+    resource,
+    resourceRelation,
+    endpoint,
+  });
+
+  const handleReorder = (id: string, oldIndex: number, newIndex: number) => {
+    const mappedItems = itemsRef.current.map((item) => ({
+      ...item,
+      order: getItemPivotOrder(item) ?? 0,
+    })) as ResourceDataType<OrderableResource>[];
+
+    const order = calculateNewSortValue(mappedItems, oldIndex, newIndex);
+
+    const originalItem = itemsRef.current.find(
+      (item) => String(item.id) === id,
+    );
+    if (originalItem == null) {
+      return;
+    }
+
+    const meta = hasMeta(originalItem) ? originalItem.meta : undefined;
+    const pivotKey = `pivot_${pivotData.field}`;
+    const pivotValue = meta?.[pivotKey];
+
+    if (pivotValue == null) {
+      return;
+    }
+
+    const reorderedItems = arrayMove(itemsRef.current, oldIndex, newIndex);
+
+    itemsRef.current = reorderedItems.map((item) => {
+      if (String(item.id) === id) {
+        return {
+          ...item,
+          meta: {
+            ...(hasMeta(item) ? item.meta : {}),
+            pivot_order: order,
+          },
+        };
+      }
+      return item;
+    });
+
+    void mutateOrder(id as ResourcePk, order, {
+      [pivotData.field]: pivotValue,
+    });
+  };
+
+  return <MultiSelect {...multiSelectProps} onReorder={handleReorder} />;
+}

--- a/src/features/abstract-resource-form/hooks/use-pivot-relation-order-mutation.ts
+++ b/src/features/abstract-resource-form/hooks/use-pivot-relation-order-mutation.ts
@@ -1,0 +1,74 @@
+"use client";
+
+import { toast } from "sonner";
+
+import { fetchMutation, useMutationWrapper } from "@/features/backend";
+import type { ModifyResourceResponse } from "@/features/backend/types";
+import { getResourceQueryName } from "@/features/resources";
+import type { Resource } from "@/features/resources";
+import type {
+  ResourcePk,
+  ResourceRelation,
+  XToManyResource,
+} from "@/features/resources/types";
+import { getToastMessages } from "@/lib/get-toast-messages";
+import { camelToSnakeCase, sanitizeId } from "@/utils";
+
+import { useArfRelation } from "./use-arf-relation";
+
+interface PivotOrderMutationVariables {
+  id: ResourcePk;
+  order: number;
+  pivotKeys: Record<string, unknown>;
+}
+
+export function usePivotRelationOrderMutation<T extends Resource>({
+  resource,
+  resourceRelation,
+  endpoint,
+}: {
+  resource: T;
+  resourceRelation: ResourceRelation<T>;
+  endpoint: string;
+}) {
+  const relationContext = useArfRelation();
+
+  const mutation = useMutationWrapper<
+    ModifyResourceResponse<T>,
+    PivotOrderMutationVariables
+  >(
+    `update__${resource}__relation_order__${relationContext?.childResource ?? "unknown"}`,
+    async ({ id, order, pivotKeys }) => {
+      const queryName = getResourceQueryName(
+        resourceRelation as XToManyResource,
+      );
+      const pathSegment = camelToSnakeCase(queryName);
+      const response = await fetchMutation<ModifyResourceResponse<T>>(
+        `${endpoint}/${pathSegment}/${sanitizeId(id)}`,
+        {
+          method: "PATCH",
+          resource,
+          body: {
+            query: pivotKeys,
+            update: { order },
+          },
+        },
+      );
+      return response;
+    },
+  );
+
+  const mutateOrder = async (
+    id: ResourcePk,
+    order: number,
+    pivotKeys: Record<string, unknown>,
+  ) =>
+    toast
+      .promise(
+        mutation.mutateAsync({ id, order, pivotKeys }),
+        getToastMessages.resource(resourceRelation).modify,
+      )
+      .unwrap();
+
+  return { mutateOrder, mutation };
+}

--- a/src/features/abstract-resource-form/types/internal.ts
+++ b/src/features/abstract-resource-form/types/internal.ts
@@ -80,3 +80,9 @@ export interface PersistedFormData<T extends Resource> {
   values: ResourceFormValues<T>;
   timestamp: number;
 }
+
+export interface ItemWithPivotOrder {
+  meta: {
+    pivot_order: number;
+  };
+}

--- a/src/features/abstract-resource-form/utils/get-item-pivot-order.ts
+++ b/src/features/abstract-resource-form/utils/get-item-pivot-order.ts
@@ -9,7 +9,7 @@ export const hasMeta = (
   typeof item.meta === "object" &&
   item.meta !== null;
 
-export const hasPivotOrder = (item: unknown): item is ItemWithPivotOrder =>
+const hasPivotOrder = (item: unknown): item is ItemWithPivotOrder =>
   hasMeta(item) && "pivot_order" in item.meta;
 
 export const getItemPivotOrder = (item: unknown): number | undefined => {

--- a/src/features/abstract-resource-form/utils/get-item-pivot-order.ts
+++ b/src/features/abstract-resource-form/utils/get-item-pivot-order.ts
@@ -1,0 +1,21 @@
+import type { ItemWithPivotOrder } from "../types/internal";
+
+export const hasMeta = (
+  item: unknown,
+): item is { meta: Record<string, unknown> } =>
+  typeof item === "object" &&
+  item !== null &&
+  "meta" in item &&
+  typeof item.meta === "object" &&
+  item.meta !== null;
+
+export const hasPivotOrder = (item: unknown): item is ItemWithPivotOrder =>
+  hasMeta(item) && "pivot_order" in item.meta;
+
+export const getItemPivotOrder = (item: unknown): number | undefined => {
+  if (hasPivotOrder(item) && typeof item.meta.pivot_order === "number") {
+    return item.meta.pivot_order;
+  }
+
+  return undefined;
+};

--- a/src/features/abstract-resource-list/components/abstract-resource-list.tsx
+++ b/src/features/abstract-resource-list/components/abstract-resource-list.tsx
@@ -4,7 +4,11 @@ import { Counter } from "@/components/core/counter";
 import { ReturnButton } from "@/components/presentation/return-button";
 import { fetchRelatedResources } from "@/features/abstract-resource-form";
 import type { ResourceDeclinableField } from "@/features/polish/types";
-import { CreateButton, Resource } from "@/features/resources";
+import {
+  CreateButton,
+  Resource,
+  isOrderableResource,
+} from "@/features/resources";
 import type {
   CreatableResource,
   EditableResource,
@@ -36,15 +40,20 @@ export async function AbstractResourceList<
   parentResource?: RoutableResource;
 }) {
   const searchParameters = await searchParams;
+  const isOrderable = isOrderableResource(resource);
 
-  const filterDefinitions = await getResourceFilterDefinitions({
-    resource,
-    includeRelations: true,
-  });
-  const sortFilters: Partial<SortFiltersFormValuesNarrowed> = {
-    ...parseSortParameter(searchParameters.sort, sortableFields),
-    filters: deserializeSortFilters(searchParameters, filterDefinitions),
-  };
+  const filterDefinitions = isOrderable
+    ? {}
+    : await getResourceFilterDefinitions({
+        resource,
+        includeRelations: true,
+      });
+  const sortFilters: Partial<SortFiltersFormValuesNarrowed> = isOrderable
+    ? {}
+    : {
+        ...parseSortParameter(searchParameters.sort, sortableFields),
+        filters: deserializeSortFilters(searchParameters, filterDefinitions),
+      };
 
   const firstPageData = await fetchPaginatedResources(
     resource,
@@ -56,17 +65,19 @@ export async function AbstractResourceList<
 
   return (
     <section className="flex h-full flex-col gap-2">
-      <header className="relative w-fit">
-        <SortFiltersPopover
-          sortableFields={sortableFields}
-          filterDefinitions={filterDefinitions}
-          defaultValues={sortFilters}
-        />
-        <Counter
-          values={sortFilters.filters ?? []}
-          label="Liczba zastosowanych filtrów"
-        />
-      </header>
+      {!isOrderable && (
+        <header className="relative w-fit">
+          <SortFiltersPopover
+            sortableFields={sortableFields}
+            filterDefinitions={filterDefinitions}
+            defaultValues={sortFilters}
+          />
+          <Counter
+            values={sortFilters.filters ?? []}
+            label="Liczba zastosowanych filtrów"
+          />
+        </header>
+      )}
       <div className="grow basis-0 overflow-y-auto pr-2">
         <InfiniteScroller
           resource={resource}

--- a/src/features/abstract-resource-list/components/infinite-scroller.tsx
+++ b/src/features/abstract-resource-list/components/infinite-scroller.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useInfiniteQuery } from "@tanstack/react-query";
+import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
+import type { QueryKey } from "@tanstack/react-query";
 import { useEffect, useMemo, useRef } from "react";
 import { useInView } from "react-intersection-observer";
 
@@ -31,17 +32,24 @@ function OrderableItems<T extends OrderableResource>({
   resource,
   items,
   relatedResources,
+  queryKey,
 }: {
   resource: T;
   items: ResourceDataType<T>[];
   relatedResources: ResourceRelations<T>;
+  queryKey: QueryKey;
 }) {
   const itemsRef = useRef(items);
   itemsRef.current = items;
 
+  const queryClient = useQueryClient();
+
   const { mutateOrder } = useOrderMutation({
     resource,
     buildPath: (id) => sanitizeId(id),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey });
+    },
   });
 
   const handleReorder = ({ id, oldIndex, newIndex }: ReorderEvent) => {
@@ -74,13 +82,15 @@ export function InfiniteScroller<T extends EditableResource>({
 }) {
   const { ref, inView } = useInView();
 
+  const queryKey = [
+    getKey.query.resourceList(resource),
+    sortFilters,
+    filterDefinitions,
+  ];
+
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useInfiniteQuery({
-      queryKey: [
-        getKey.query.resourceList(resource),
-        sortFilters,
-        filterDefinitions,
-      ],
+      queryKey,
       queryFn: async ({ pageParam }) =>
         fetchPaginatedResources(
           resource,
@@ -114,6 +124,7 @@ export function InfiniteScroller<T extends EditableResource>({
           items={flatData as ResourceDataType<typeof resource>[]}
           resource={resource}
           relatedResources={relatedResources}
+          queryKey={queryKey}
         />
       ) : (
         <ArlItems

--- a/src/features/abstract-resource-list/hooks/use-order-mutation.ts
+++ b/src/features/abstract-resource-list/hooks/use-order-mutation.ts
@@ -12,6 +12,7 @@ interface UseOrderMutationOptions<T extends Resource> {
   resource: T;
   buildPath: (itemId: ResourcePk) => string;
   onError?: () => void;
+  onSuccess?: (data: ModifyResourceResponse<T>) => void;
 }
 
 interface OrderMutationVariables {
@@ -23,6 +24,7 @@ export function useOrderMutation<T extends Resource>({
   resource,
   buildPath,
   onError,
+  onSuccess,
 }: UseOrderMutationOptions<T>) {
   const mutation = useMutationWrapper<
     ModifyResourceResponse<T>,
@@ -41,7 +43,7 @@ export function useOrderMutation<T extends Resource>({
       );
       return response;
     },
-    { onError },
+    { onError, onSuccess },
   );
 
   const mutateOrder = async (id: ResourcePk, order: number) =>

--- a/src/features/resources/data/resource-metadata.ts
+++ b/src/features/resources/data/resource-metadata.ts
@@ -386,7 +386,6 @@ export const RESOURCE_METADATA = {
   [Resource.Contributors]: {
     queryName: "contributors",
     apiPath: "contributors",
-    orderable: true,
     itemMapper: (item) => ({
       name: item.name,
     }),
@@ -722,6 +721,7 @@ export const RESOURCE_METADATA = {
         relationInputs: {
           [Resource.Contributors]: {
             type: RelationType.ManyToMany,
+            orderable: true,
             pivotData: {
               field: "role_id",
               relatedResource: Resource.Roles,

--- a/src/features/resources/types/relations.ts
+++ b/src/features/resources/types/relations.ts
@@ -54,6 +54,7 @@ export interface PivotRelationDefinition {
   foreignKey?: never;
   label?: DeclinableNoun;
   pivotData?: PivotDataDefinition;
+  orderable?: boolean;
 }
 /** Relation definitions between T and L, where T is the main resource and L is the related resource. */
 export type RelationDefinition<T extends Resource, L extends Resource> =

--- a/src/tests/e2e/specs/guide-articles.spec.ts
+++ b/src/tests/e2e/specs/guide-articles.spec.ts
@@ -2,7 +2,6 @@ import { faker } from "@faker-js/faker";
 import { expect, test } from "@playwright/test";
 import type { Locator, Page, Response } from "@playwright/test";
 
-import { LIST_RESULTS_PER_PAGE } from "@/features/abstract-resource-list/node";
 import { FetchError, fetchMutation, uploadFile } from "@/features/backend/node";
 import type {
   MessageResponse,
@@ -22,7 +21,6 @@ import { generateAccessToken } from "../api/generate-access-token";
 import { MOCK_IMAGE_PATH } from "../constants";
 import { expectArfSuccess } from "../utils/expect-arf-success";
 import { returnFromArf } from "../utils/return-from-arf";
-import { setArlSortFilters } from "../utils/set-arl-filters";
 
 const resource = Resource.GuideArticles;
 type ResourceType = typeof resource;
@@ -129,15 +127,39 @@ async function navigateToArticles(page: Page) {
 
 /** Sets the abstract resource list filters such that the only displayed article is the provided one. */
 async function filterSpecificArticle(page: Page, article: MockGuideArticle) {
-  await setArlSortFilters(page, resource, {
-    filters: [
-      {
-        field: "shortDesc",
-        value: article.shortDesc,
-      },
-    ],
-  });
+  await expect(page.locator("li").first()).toBeVisible({ timeout: 15_000 });
+
+  const articleCard = page.locator("li").filter({ hasText: article.title });
+
+  let attempts = 0;
+  while (!(await articleCard.isVisible()) && attempts < 50) {
+    attempts++;
+    const loadMoreButton = page.getByRole("button", { name: "Załaduj więcej" });
+    if (await loadMoreButton.isVisible()) {
+      const currentCount = await page.locator("li").count();
+      try {
+        await loadMoreButton.scrollIntoViewIfNeeded({ timeout: 1000 });
+      } catch {
+        continue;
+      }
+      try {
+        await expect(async () => {
+          const newCount = await page.locator("li").count();
+          expect(newCount).toBeGreaterThan(currentCount);
+        }).toPass({ timeout: 5000 });
+      } catch {
+        break;
+      }
+    } else {
+      break;
+    }
+  }
+
+  await expect(articleCard).toBeVisible();
 }
+
+const getArticleCard = (page: Page, article: MockGuideArticle) =>
+  page.locator("li").filter({ hasText: article.title });
 
 test.describe("Guide Articles CRUD", () => {
   test.beforeAll(async () => {
@@ -190,6 +212,7 @@ test.describe("Guide Articles CRUD", () => {
           .split("/")
           .includes(getResourceMetadata(resource).apiPath),
     );
+    let articleData: CreateArticleResponse | null = null;
     try {
       await test.step("Submit create article form", async () => {
         const button = page.getByRole("button", { name: /utwórz/i });
@@ -198,6 +221,9 @@ test.describe("Guide Articles CRUD", () => {
         await expectArfSuccess(page);
       });
 
+      const articleResponse = await articlePromise;
+      articleData = (await articleResponse.json()) as CreateArticleResponse;
+
       await test.step("Ensure creation is persisted", async () => {
         await returnFromArf(page, resource);
         await filterSpecificArticle(page, testArticle);
@@ -205,10 +231,9 @@ test.describe("Guide Articles CRUD", () => {
         await expect(page.getByText(testArticle.shortDesc)).toBeVisible();
       });
     } finally {
-      const articleResponse = await articlePromise;
-      const articleData =
-        (await articleResponse.json()) as CreateArticleResponse;
-      await deleteTestArticle({ ...articleData.data, imageKey }, true);
+      if (articleData != null) {
+        await deleteTestArticle({ ...articleData.data, imageKey }, true);
+      }
     }
   });
 
@@ -216,13 +241,13 @@ test.describe("Guide Articles CRUD", () => {
     const testArticle = await createTestArticle();
     try {
       await navigateToArticles(page);
-      await expect(getEditButton(page)).toHaveCount(LIST_RESULTS_PER_PAGE);
       await filterSpecificArticle(page, testArticle);
 
-      await expect(getEditButton(page)).toHaveCount(1);
+      const articleCard = getArticleCard(page, testArticle);
+      await expect(getEditButton(articleCard)).toHaveCount(1);
 
-      await expect(page.getByText(testArticle.title)).toBeVisible();
-      await expect(page.getByText(testArticle.shortDesc)).toBeVisible();
+      await expect(articleCard.getByText(testArticle.title)).toBeVisible();
+      await expect(articleCard.getByText(testArticle.shortDesc)).toBeVisible();
     } finally {
       await deleteTestArticle(testArticle);
     }
@@ -236,7 +261,7 @@ test.describe("Guide Articles CRUD", () => {
       await test.step("Change article name", async () => {
         await navigateToArticles(page);
         await filterSpecificArticle(page, testArticle);
-        await getEditButton(page).click();
+        await getEditButton(getArticleCard(page, testArticle)).click();
         await page.waitForURL(`/${resource}/edit/*`);
         const submitButton = page.getByRole("button", { name: /zapisz/i });
         // TODO: for some reason the button is sometimes initially enabled
@@ -260,9 +285,15 @@ test.describe("Guide Articles CRUD", () => {
 
       await test.step("Ensure update is persisted", async () => {
         await returnFromArf(page, resource);
+        await page.reload();
         await filterSpecificArticle(page, newArticle);
-        await expect(page.getByText(newArticle.title)).toBeVisible();
-        await expect(page.getByText(newArticle.shortDesc)).toBeVisible();
+        const updatedArticleCard = getArticleCard(page, newArticle);
+        await expect(
+          updatedArticleCard.getByText(newArticle.title),
+        ).toBeVisible();
+        await expect(
+          updatedArticleCard.getByText(newArticle.shortDesc),
+        ).toBeVisible();
       });
     } finally {
       await deleteTestArticle(testArticle);
@@ -274,7 +305,7 @@ test.describe("Guide Articles CRUD", () => {
     try {
       await navigateToArticles(page);
       await filterSpecificArticle(page, testArticle);
-      await getEditButton(page).click();
+      await getEditButton(getArticleCard(page, testArticle)).click();
 
       const deleteButton = getDeleteButton(page);
       await expect(deleteButton).toBeVisible();
@@ -282,10 +313,8 @@ test.describe("Guide Articles CRUD", () => {
       await page.getByRole("button", { name: /^usuń$/i }).click();
 
       await expect(page.getByText(/pomyślnie usunięto artykuł/i)).toBeVisible();
-
-      await filterSpecificArticle(page, testArticle);
-      await expect(getEditButton(page)).toBeHidden();
-      await expect(getDeleteButton(page)).toBeHidden();
+      await page.reload();
+      await expect(getArticleCard(page, testArticle)).toBeHidden();
     } finally {
       await deleteTestArticle(testArticle);
     }

--- a/src/tests/e2e/specs/milestones.spec.ts
+++ b/src/tests/e2e/specs/milestones.spec.ts
@@ -67,6 +67,23 @@ test.describe("About Us Versions CRUD", () => {
     });
     await konradPivotData.scrollIntoViewIfNeeded();
     await expect(konradPivotData).toBeVisible();
+
+    try {
+      await expect(konradPivotData).toHaveText("Dodaj");
+    } catch {
+      await konradPivotData.click();
+      const deleteButton = page.getByRole("option", {
+        name: "Usuń kontrybutora",
+      });
+      try {
+        await deleteButton.waitFor({ state: "visible", timeout: 2000 });
+        await deleteButton.click();
+        await expect(konradPivotData).toHaveText("Dodaj");
+      } catch {
+        await page.keyboard.press("Escape");
+      }
+    }
+
     await expect(konradPivotData).toHaveText("Dodaj");
     await konradPivotData.click();
     for (const role of ROLES) {


### PR DESCRIPTION
Ogólnie z jakiegoś powodu dało się sortować orderable resource'y (co trochę nie ma sensu - bo co niby działo się gdy zmieniało się sortowanie i wtedy przeciągało kolejność xD), stąd te niektóre zmiany w tym do testów

Na przyszłość można pomyśleć jak ten pivot ordering jakoś lepiej zintegrować z typami resourców, na razie to jest tak żeby było